### PR TITLE
Some bug fixes to smiles2mean

### DIFF
--- a/DrugEmbedding/decode.py
+++ b/DrugEmbedding/decode.py
@@ -247,7 +247,7 @@ def smiles2mean(configs, smiles_x, model):
     for i in tokens:
         input_sequence.append(w2i[i])
     input_sequence.append(w2i['<eos>'])
-    input_sequence = input_sequence + [0] * (configs['max_sequence_length'] - len(input_sequence) - 1)
+    input_sequence = input_sequence + [0] * (configs['max_sequence_length'] - len(input_sequence))
     input_sequence = np.asarray(input_sequence)
     input_sequence = torch.from_numpy(input_sequence).unsqueeze(0)
     sequence_length = torch.tensor([len(smiles_x)+1])

--- a/DrugEmbedding/decode.py
+++ b/DrugEmbedding/decode.py
@@ -250,7 +250,7 @@ def smiles2mean(configs, smiles_x, model):
     input_sequence = input_sequence + [0] * (configs['max_sequence_length'] - len(input_sequence))
     input_sequence = np.asarray(input_sequence)
     input_sequence = torch.from_numpy(input_sequence).unsqueeze(0)
-    sequence_length = torch.tensor([len(smiles_x)+1])
+    sequence_length = torch.tensor([len(tokens)+2])
 
     # run through encoder
     hidden = model.encoder(input_sequence, sequence_length)


### PR DESCRIPTION
- Fix off by one error when padding shorter sequences
- Sequence length calculation was off. Some tokens are represented by more than one character, so basing the calculation off the origin smiles length was incorrect.